### PR TITLE
📦 Bump npm:http-proxy:1.11.1 from 1.11.1 to 1.18.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "server.js"
   ],
   "dependencies": {
-    "http-proxy": "1.11.1",
+    "http-proxy": "1.18.1",
     "proxy-from-env": "0.0.1"
   },
   "devDependencies": {


### PR DESCRIPTION
Lineaje has automatically created this pull request to resolve the following CVEs:
| CVE ID  | Severity | Description       |
|-------|-----|-----------|
| GHSA-6x33-pw7p-hmpq | High  | Denial of Service in http-proxy |

You can merge this PR once the tests pass and the changes are reviewed.

Thank you for reviewing the update! :rocket:
